### PR TITLE
Solved a bug in slideshow image issue

### DIFF
--- a/Flutter/shelter_partner/lib/views/pages/visitor_page.dart
+++ b/Flutter/shelter_partner/lib/views/pages/visitor_page.dart
@@ -352,8 +352,14 @@ class _SlideshowScreenState extends State<SlideshowScreen> {
     // Shuffle the list of animals
     _shuffledAnimals = List.from(widget.animals)..shuffle();
 
-    // Set the initial image URL and animal
-    _setCurrentImage();
+    // Set the initial image URL and animal, ensuring it skips animals without images
+    _currentIndex = 0;
+    do {
+      _setCurrentImage();
+      if (_currentImageUrl.isEmpty) {
+        _currentIndex = (_currentIndex + 1) % _shuffledAnimals.length;
+      }
+    } while (_currentImageUrl.isEmpty && _currentIndex != 0);
 
     // Start the slideshow
     _startSlideshow();


### PR DESCRIPTION
The issue of displaying slides without images during the slideshow had already been resolved earlier. However, upon further review, a remaining bug was identified: the check for empty images was not enabled in the `initState` method. This oversight caused the first slide to occasionally appear without an image. The issue has now been addressed and resolved.